### PR TITLE
add default constructor

### DIFF
--- a/include/rpc/server.h
+++ b/include/rpc/server.h
@@ -4,10 +4,9 @@
 #define SERVER_H_S0HB5KXY
 
 #include "rpc/config.h"
-#include "rpc/msgpack.hpp"
-#include "rpc/dispatcher.h"
-
 #include "rpc/detail/pimpl.h"
+#include "rpc/dispatcher.h"
+#include "rpc/msgpack.hpp"
 
 namespace rpc {
 
@@ -26,99 +25,105 @@ class server_session;
 //! functions to start listening on the port.
 //! This class is not copyable, but moveable.
 class server {
-public:
-    //! \brief Constructs a server that listens on the localhost on the
-    //! specified port.
-    //!
-    //! \param port The port number to listen on.
-    explicit server(uint16_t port);
+ public:
+  //! \brief Constructs a server that not listens on any port, when
+  //! the port cannot be determined on the constructor.
+  server();
+  //! \brief Constructs a server that listens on the localhost on the
+  //! specified port.
+  //!
+  //! \param port The port number to listen on.
+  explicit server(uint16_t port);
 
-    //! \brief Move constructor. This is implemented by calling the
-    //! move assignment operator.
-    //!
-    //! \param other The other instance to move from.
-    server(server&& other) noexcept;
+  //! \brief Move constructor. This is implemented by calling the
+  //! move assignment operator.
+  //!
+  //! \param other The other instance to move from.
+  server(server&& other) noexcept;
 
-    //! \brief Constructs a server that listens on the specified address on
-    //! the specified port.
-    //!
-    //! \param address The address to bind to. This only works if oee of your
-    //! network adapaters control the given address.
-    //! \param port The port number to listen on.
-    server(std::string const &address, uint16_t port);
+  //! \brief Constructs a server that listens on the specified address on
+  //! the specified port.
+  //!
+  //! \param address The address to bind to. This only works if oee of your
+  //! network adapaters control the given address.
+  //! \param port The port number to listen on.
+  server(std::string const& address, uint16_t port);
 
-    //! \brief Destructor.
-    //!
-    //! When the server is destroyed, all ongoin sessions are closed gracefully.
-    ~server();
+  //! \brief Destructor.
+  //!
+  //! When the server is destroyed, all ongoin sessions are closed gracefully.
+  ~server();
 
-    //! \brief Move assignment operator.
-    //!
-    //! \param other The other instance to move from.
-    //! \return The result of the assignment.
-    server& operator=(server&& other);
+  void listen(uint16_t port);
 
-    //! \brief Starts the server loop. This is a blocking call.
-    //!
-    //! First and foremost, running the event loop causes the server to start
-    //! listening on the specified port. Also, as connections are established
-    //! and calls are made by clients, the server executes the calls as part
-    //! of this call. This means that the handlers are executed on the thread
-    //! that calls `run`. Reads and writes are initiated by this function
-    //! internally as well.
-    void run();
+  //! \brief Move assignment operator.
+  //!
+  //! \param other The other instance to move from.
+  //! \return The result of the assignment.
+  server& operator=(server&& other);
 
-    //! \brief Starts the server loop on one or more threads. This is a
-    //! non-blocking call.
-    //!
-    //! This function behaves similarly to `run`, except the event loop is
-    //! optionally started on different threads. Effectively this sets up a
-    //! worker thread pool for the server. Handlers will be executed on one
-    //! of the threads.
-    //!
-    //! \param worker_threads The number of worker threads to start.
-    void async_run(std::size_t worker_threads = 1);
+  //! \brief Starts the server loop. This is a blocking call.
+  //!
+  //! First and foremost, running the event loop causes the server to start
+  //! listening on the specified port. Also, as connections are established
+  //! and calls are made by clients, the server executes the calls as part
+  //! of this call. This means that the handlers are executed on the thread
+  //! that calls `run`. Reads and writes are initiated by this function
+  //! internally as well.
+  void run();
 
-    //! \brief Binds a functor to a name so it becomes callable via RPC.
-    //!
-    //! This function template accepts a wide range of callables. The arguments
-    //! and return types of these callables should be serializable by msgpack.
-    //! `bind` effectively generates a suitable, light-weight compile-time
-    //! wrapper for the functor.
-    //!
-    //! \param name The name of the functor.
-    //! \param func The functor to bind.
-    //! \tparam F The type of the functor.
-    template <typename F> void bind(std::string const &name, F func) {
-        disp_->bind(name, func);
-    }
+  //! \brief Starts the server loop on one or more threads. This is a
+  //! non-blocking call.
+  //!
+  //! This function behaves similarly to `run`, except the event loop is
+  //! optionally started on different threads. Effectively this sets up a
+  //! worker thread pool for the server. Handlers will be executed on one
+  //! of the threads.
+  //!
+  //! \param worker_threads The number of worker threads to start.
+  void async_run(std::size_t worker_threads = 1);
 
-    //! \brief Sets the exception behavior in handlers. By default,
-    //! handlers throwing will crash the server. If suppressing is on,
-    //! the server will try to gather textual data and return it to
-    //! the client as an error response.
-    //! \note Setting this flag only affects subsequent connections.
-    void suppress_exceptions(bool suppress);
+  //! \brief Binds a functor to a name so it becomes callable via RPC.
+  //!
+  //! This function template accepts a wide range of callables. The arguments
+  //! and return types of these callables should be serializable by msgpack.
+  //! `bind` effectively generates a suitable, light-weight compile-time
+  //! wrapper for the functor.
+  //!
+  //! \param name The name of the functor.
+  //! \param func The functor to bind.
+  //! \tparam F The type of the functor.
+  template <typename F>
+  void bind(std::string const& name, F func) {
+    disp_->bind(name, func);
+  }
 
-    //! \brief Stops the server.
-    //! \note This should not be called from worker threads.
-    void stop();
+  //! \brief Sets the exception behavior in handlers. By default,
+  //! handlers throwing will crash the server. If suppressing is on,
+  //! the server will try to gather textual data and return it to
+  //! the client as an error response.
+  //! \note Setting this flag only affects subsequent connections.
+  void suppress_exceptions(bool suppress);
 
-    //! \brief Returns port
-    //! \note The port
-    unsigned short port() const;
+  //! \brief Stops the server.
+  //! \note This should not be called from worker threads.
+  void stop();
 
-    //! \brief Closes all sessions gracefully.
-    void close_sessions();
+  //! \brief Returns port
+  //! \note The port
+  unsigned short port() const;
 
-    //! \brief Closes a specific session.
-    void close_session(std::shared_ptr<detail::server_session> const& s);
+  //! \brief Closes all sessions gracefully.
+  void close_sessions();
 
-private:
-	RPCLIB_DECLARE_PIMPL()
-    std::shared_ptr<detail::dispatcher> disp_;
+  //! \brief Closes a specific session.
+  void close_session(std::shared_ptr<detail::server_session> const& s);
+
+ private:
+  RPCLIB_DECLARE_PIMPL()
+  std::shared_ptr<detail::dispatcher> disp_;
 };
 
-} /* rpc */
+}  // namespace rpc
 
 #endif /* end of include guard: SERVER_H_S0HB5KXY */

--- a/lib/rpc/server.cc
+++ b/lib/rpc/server.cc
@@ -1,157 +1,159 @@
 #include "rpc/server.h"
 
+#include <stdint.h>
+
 #include <atomic>
 #include <memory>
 #include <stdexcept>
-#include <stdint.h>
 #include <thread>
 
 #include "asio.hpp"
 #include "format.h"
-
-#include "rpc/this_server.h"
 #include "rpc/detail/dev_utils.h"
-#include "rpc/detail/log.h"
 #include "rpc/detail/log.h"
 #include "rpc/detail/server_session.h"
 #include "rpc/detail/thread_group.h"
+#include "rpc/this_server.h"
 
 using namespace rpc::detail;
 using RPCLIB_ASIO::ip::tcp;
 using namespace RPCLIB_ASIO;
 
-
 namespace rpc {
 
 struct server::impl {
-    impl(server *parent, std::string const &address, uint16_t port)
-        : parent_(parent),
-          io_(),
-          acceptor_(io_),
-          socket_(io_),
-          suppress_exceptions_(false) {
-            auto ep = tcp::endpoint(ip::address::from_string(address), port);
-            acceptor_.open(ep.protocol());
-            acceptor_.set_option(tcp::acceptor::reuse_address(true));
-            acceptor_.bind(ep);
-            acceptor_.listen();
-          }
+  impl(server *parent, std::string const &address, uint16_t port)
+      : parent_(parent),
+        io_(),
+        acceptor_(io_),
+        socket_(io_),
+        suppress_exceptions_(false) {
+    auto ep = tcp::endpoint(ip::address::from_string(address), port);
+    acceptor_.open(ep.protocol());
+    acceptor_.set_option(tcp::acceptor::reuse_address(true));
+    acceptor_.bind(ep);
+    acceptor_.listen();
+  }
 
-    impl(server *parent, uint16_t port)
-        : parent_(parent),
-          io_(),
-          acceptor_(io_),
-          socket_(io_),
-          suppress_exceptions_(false) {
-            auto ep = tcp::endpoint(tcp::v4(), port);
-            acceptor_.open(ep.protocol());
-            acceptor_.set_option(tcp::acceptor::reuse_address(true));
-            acceptor_.bind(ep);
-            acceptor_.listen();            
-          }
+  impl(server *parent, uint16_t port)
+      : parent_(parent),
+        io_(),
+        acceptor_(io_),
+        socket_(io_),
+        suppress_exceptions_(false) {
+    auto ep = tcp::endpoint(tcp::v4(), port);
+    acceptor_.open(ep.protocol());
+    acceptor_.set_option(tcp::acceptor::reuse_address(true));
+    acceptor_.bind(ep);
+    acceptor_.listen();
+  }
 
-    void start_accept() {
-        acceptor_.async_accept(socket_, [this](std::error_code ec) {
-            if (!ec) {
-                LOG_INFO("Accepted connection.");
-                auto s = std::make_shared<server_session>(
-                    parent_, &io_, std::move(socket_), parent_->disp_,
-                    suppress_exceptions_);
-                s->start();
-                std::unique_lock<std::mutex> lock(sessions_mutex_);
-                sessions_.push_back(s);
-            } else {
-                LOG_ERROR("Error while accepting connection: {}", ec);
-            }
-            if (!this_server().stopping())
-                start_accept();
-            // TODO: allow graceful exit [sztomi 2016-01-13]
-        });
-    }
-
-    void close_sessions() {
+  void start_accept() {
+    acceptor_.async_accept(socket_, [this](std::error_code ec) {
+      if (!ec) {
+        LOG_INFO("Accepted connection.");
+        auto s = std::make_shared<server_session>(
+            parent_, &io_, std::move(socket_), parent_->disp_,
+            suppress_exceptions_);
+        s->start();
         std::unique_lock<std::mutex> lock(sessions_mutex_);
-        auto sessions_copy = sessions_;
-        sessions_.clear();
-        lock.unlock();
+        sessions_.push_back(s);
+      } else {
+        LOG_ERROR("Error while accepting connection: {}", ec);
+      }
+      if (!this_server().stopping()) start_accept();
+      // TODO: allow graceful exit [sztomi 2016-01-13]
+    });
+  }
 
-        // release shared pointers outside of the mutex
-        for (auto &session : sessions_copy) {
-            session->close();
-        }
+  void close_sessions() {
+    std::unique_lock<std::mutex> lock(sessions_mutex_);
+    auto sessions_copy = sessions_;
+    sessions_.clear();
+    lock.unlock();
 
-        if (this_server().stopping())
-            acceptor_.cancel();
+    // release shared pointers outside of the mutex
+    for (auto &session : sessions_copy) {
+      session->close();
     }
 
-    void stop() {
-        io_.stop();
-        loop_workers_.join_all();
-    }
+    if (this_server().stopping()) acceptor_.cancel();
+  }
 
-    unsigned short port() const {
-        return acceptor_.local_endpoint().port();        
-    }
+  void stop() {
+    io_.stop();
+    loop_workers_.join_all();
+  }
 
-    server *parent_;
-    io_service io_;
-    ip::tcp::acceptor acceptor_;
-    ip::tcp::socket socket_;
-    rpc::detail::thread_group loop_workers_;
-    std::vector<std::shared_ptr<server_session>> sessions_;
-    std::atomic_bool suppress_exceptions_;
-    RPCLIB_CREATE_LOG_CHANNEL(server)
-    std::mutex sessions_mutex_;
+  unsigned short port() const { return acceptor_.local_endpoint().port(); }
+
+  server *parent_;
+  io_service io_;
+  ip::tcp::acceptor acceptor_;
+  ip::tcp::socket socket_;
+  rpc::detail::thread_group loop_workers_;
+  std::vector<std::shared_ptr<server_session>> sessions_;
+  std::atomic_bool suppress_exceptions_;
+  RPCLIB_CREATE_LOG_CHANNEL(server)
+  std::mutex sessions_mutex_;
 };
 
 RPCLIB_CREATE_LOG_CHANNEL(server)
 
+server::server() {}
+
 server::server(uint16_t port)
-    : pimpl(new server::impl(this, port)), disp_(std::make_shared<dispatcher>()) {
-    LOG_INFO("Created server on localhost:{}", port);
-    pimpl->start_accept();
+    : pimpl(new server::impl(this, port)),
+      disp_(std::make_shared<dispatcher>()) {
+  LOG_INFO("Created server on localhost:{}", port);
+  pimpl->start_accept();
 }
 
-server::server(server&& other) noexcept {
-    *this = std::move(other);
-}
+server::server(server &&other) noexcept { *this = std::move(other); }
 
 server::server(std::string const &address, uint16_t port)
     : pimpl(new server::impl(this, address, port)),
-    disp_(std::make_shared<dispatcher>()) {
-    LOG_INFO("Created server on address {}:{}", address, port);
-    pimpl->start_accept();
+      disp_(std::make_shared<dispatcher>()) {
+  LOG_INFO("Created server on address {}:{}", address, port);
+  pimpl->start_accept();
 }
 
 server::~server() {
-    if (pimpl) {
-        pimpl->stop();
-    }
+  if (pimpl) {
+    pimpl->stop();
+  }
 }
 
-server& server::operator=(server &&other) {
-    if (this != &other) {
-        pimpl = std::move(other.pimpl);
-        other.pimpl = nullptr;
-        disp_ = std::move(other.disp_);
-        other.disp_ = nullptr;
-    }
-    return *this;
+void server::listen(uint16_t port) {
+  LOG_INFO("Created server on localhost:{}", port);
+  pimpl.reset(new server::impl(this, port));
+  disp_ = std::make_shared<dispatcher>();
+  pimpl->start_accept();
+}
+
+server &server::operator=(server &&other) {
+  if (this != &other) {
+    pimpl = std::move(other.pimpl);
+    other.pimpl = nullptr;
+    disp_ = std::move(other.disp_);
+    other.disp_ = nullptr;
+  }
+  return *this;
 }
 
 void server::suppress_exceptions(bool suppress) {
-    pimpl->suppress_exceptions_ = suppress;
+  pimpl->suppress_exceptions_ = suppress;
 }
 
 void server::run() { pimpl->io_.run(); }
 
 void server::async_run(std::size_t worker_threads) {
-    pimpl->loop_workers_.create_threads(worker_threads, [this]() {
-        name_thread("server");
-        LOG_INFO("Starting");
-        pimpl->io_.run();
-        LOG_INFO("Exiting");
-    });
+  pimpl->loop_workers_.create_threads(worker_threads, [this]() {
+    name_thread("server");
+    LOG_INFO("Starting");
+    pimpl->io_.run();
+    LOG_INFO("Exiting");
+  });
 }
 
 void server::stop() { pimpl->stop(); }
@@ -172,4 +174,4 @@ void server::close_session(std::shared_ptr<detail::server_session> const &s) {
   // session shared pointer is released outside of the mutex
 }
 
-} /* rpc */
+}  // namespace rpc


### PR DESCRIPTION
I added a default constructor to the class server. It's useful when the port cannot be determined when constructing a server. 

For example, if a server is a member object of class `A`, each time `A` constructs, we need to provide a port to construct the server if we don't provide a default constructor. However, when a port is occupied already by another server, and the program is not aware of it and we still use the same port, there could cause an address conflict. 

In this case, by provide a default constructor, we can catch an exception for address conflict and find a not used port automatically, then construct the member object by `std::move(rpc::server(port))`.