### PR TITLE
fix compile error for gcc 4.9

### DIFF
--- a/include/rpc/rpc_error.h
+++ b/include/rpc/rpc_error.h
@@ -4,6 +4,7 @@
 #define RPC_ERROR_H_NEOOSTKY
 
 #include <exception>
+#include <system_error>
 
 #include "rpc/msgpack.hpp"
 


### PR DESCRIPTION
Older compilers like gcc 4.9 for raspberry pi and 5.3 for mips report compile error due to missing declaration of `std::system_error`. Adding inclusion of the respective header file solves the issue